### PR TITLE
Stripe confirmation

### DIFF
--- a/app/controllers/charge_controller.rb
+++ b/app/controllers/charge_controller.rb
@@ -1,7 +1,7 @@
 class ChargeController < ApplicationController
-  def index
-    @ticket = Ticket.find_by_guid(cookies[:ticket_guid])
+  before_action :find_ticket
 
+  def index
     @stripe_session = Stripe::Checkout::Session.create(
       payment_method_types: ['card'],
       line_items: [{
@@ -14,5 +14,16 @@ class ChargeController < ApplicationController
       success_url: ENV.fetch('STRIPE_SUCCESS_URL', 'https://ticketer.test/success?session_id={CHECKOUT_SESSION_ID}'),
       cancel_url: ENV.fetch('STRIPE_CANCEL_URL', 'https://ticketer.test/cancel'),
     )
+  end
+
+  def success
+    @ticket.stripe_checkout_session_id = params[:session_id]
+    @ticket.save!
+  end
+
+  private
+
+  def find_ticket
+    @ticket = Ticket.find_by_guid(cookies[:ticket_guid])
   end
 end

--- a/app/controllers/charge_controller.rb
+++ b/app/controllers/charge_controller.rb
@@ -11,8 +11,8 @@ class ChargeController < ApplicationController
         currency: 'gbp',
         quantity: 1,
       }],
-      success_url: 'https://ticketer.test/success?session_id={CHECKOUT_SESSION_ID}',
-      cancel_url: 'https://ticketer.test/cancel',
+      success_url: ENV.fetch('STRIPE_SUCCESS_URL', 'https://ticketer.test/success?session_id={CHECKOUT_SESSION_ID}'),
+      cancel_url: ENV.fetch('STRIPE_CANCEL_URL', 'https://ticketer.test/cancel'),
     )
   end
 end

--- a/db/migrate/20200223162212_add_stripe_info_to_ticket.rb
+++ b/db/migrate/20200223162212_add_stripe_info_to_ticket.rb
@@ -1,0 +1,7 @@
+class AddStripeInfoToTicket < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tickets, :stripe_checkout_session_id, :string
+    add_column :tickets, :stripe_confirmed, :boolean
+    add_column :tickets, :stripe_confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,9 @@ ActiveRecord::Schema.define(version: 2020_02_23_162212) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "stripe_checkout_session_id"
+    t.boolean "stripe_confirmed"
+    t.datetime "stripe_confirmed_at"
     t.index ["event_id"], name: "index_tickets_on_event_id"
     t.index ["guid"], name: "index_tickets_on_guid", unique: true
     t.index ["name"], name: "index_tickets_on_name", unique: true

--- a/spec/controllers/allocate_controller_spec.rb
+++ b/spec/controllers/allocate_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "Allocate", type: :request do
+RSpec.describe AllocateController, type: :controller do
 
   describe "POST /allocate" do
     let(:ticket) { create(:ticket) }
 
     it "returns http success" do
-      post "/allocate", params: { name: "John Smith", event_id: ticket.event_id}
+      post :index, params: { name: "John Smith", event_id: ticket.event_id}
 
       ticket.reload
       expect(ticket.claimed?).to eq(true)

--- a/spec/controllers/charge_controller_spec.rb
+++ b/spec/controllers/charge_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ChargeController, type: :controller do
+
+  describe "GET /success" do
+    let(:ticket) { create(:ticket) }
+
+    let(:checkout_session_id) { "some-stripe-id" }
+
+    before do
+      request.cookies['ticket_guid'] = ticket.guid
+    end
+
+    it "returns http success" do
+      get :success, params: { session_id: checkout_session_id }
+
+      ticket.reload
+      expect(ticket.stripe_checkout_session_id).to eq(checkout_session_id)
+    end
+  end
+
+end

--- a/spec/controllers/landing_controller_spec.rb
+++ b/spec/controllers/landing_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Landings", type: :request do
+RSpec.describe LandingController, type: :controller do
 
   describe "GET /" do
     before do
@@ -8,7 +8,7 @@ RSpec.describe "Landings", type: :request do
     end
 
     it "returns http success" do
-      get "/"
+      get :index
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
This PR adds the information onto a ticket to check that it has been confirmed by stripe and allowing that to happen through the `/success` endpoint. 

The `confirmation` and `confirmed_at` fields will be used later by the webhook.