### PR TITLE
Free up claimed tickets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'stripe'
+
+gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    connection_pool (2.2.2)
     crass (1.0.6)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -125,6 +126,8 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -159,6 +162,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.1.3)
     regexp_parser (1.6.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
@@ -192,6 +196,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sidekiq (6.0.5)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -252,6 +261,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.beta)
   sass-rails (>= 6)
   selenium-webdriver
+  sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   stripe

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec rails s
+worker: bundle exec sidekiq -t 25 -c 2

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -15,10 +15,17 @@ class Ticket < ApplicationRecord
     self.name = customer_name
     self.status = :claimed
     save!
+    TicketCleanupWorker.perform_in(5.minutes, self.id)
   end
 
   def sell!
     self.status = "sold"
+    save!
+  end
+
+  def cleanup!
+    self.status = "available"
+    self.name = nil
     save!
   end
 

--- a/app/workers/ticket_cleanup_worker.rb
+++ b/app/workers/ticket_cleanup_worker.rb
@@ -1,0 +1,11 @@
+class TicketCleanupWorker
+  include Sidekiq::Worker
+
+  def perform(ticket_id)
+    @ticket = Ticket.find(ticket_id)
+
+    return if @ticket.status == "sold"
+
+    @ticket.cleanup!
+  end
+end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe WebhookController, type: :request do
 
     let!(:ticket) {
       create(:ticket,
-        status: "claimed",
-        stripe_checkout_session_id: stripe_checkout_id
+        :claimed,
+        stripe_checkout_session_id: stripe_checkout_id,
       )
     }
 

--- a/spec/factories/ticket.rb
+++ b/spec/factories/ticket.rb
@@ -3,5 +3,17 @@ FactoryBot.define do
     name { nil }
     guid { SecureRandom.uuid }
     event { create(:event) }
+
+    trait :claimed do
+      name { "John Smith" }
+      status { "claimed" }
+      stripe_checkout_session_id { "some-random-stripe-id" }
+    end
+
+    trait :sold do
+      name { "John Smith" }
+      status { "sold" }
+      stripe_checkout_session_id { "some-random-stripe-id" }
+    end
   end
 end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -8,15 +8,25 @@ RSpec.describe Ticket, type: :model do
 
   describe "#claim!" do
     it "claims the ticket" do
-      ticket.claim!("Tommy")
+      expect{ticket.claim!("Tommy")}.to change(TicketCleanupWorker.jobs, :size).by(1)
       expect(ticket.name).to eq("Tommy")
       expect(ticket.claimed?).to eq(true)
     end
   end
 
-  describe '#set_guid' do
+  describe "#set_guid" do
     it "sets a guid before create" do
       expect(ticket.guid).not_to be_nil
+    end
+  end
+
+  describe "cleanup!" do
+    let(:ticket) { create(:ticket, :claimed) }
+
+    it "unclaims the ticket" do
+      ticket.cleanup!
+      expect(ticket.name).to be_nil
+      expect(ticket.status).to eq("available")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,9 @@ require 'rspec/rails'
 
 require_relative "./support/stripe_test_helper"
 
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/workers/ticket_cleanup_worker_spec.rb
+++ b/spec/workers/ticket_cleanup_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe TicketCleanupWorker do
+  describe "#perform" do
+    context "for a sold ticket" do
+      let(:ticket) { create(:ticket, :sold) }
+
+      it "does nothing" do
+        expect{described_class.new.perform(ticket.id)}.to_not change{ticket.status}
+      end
+    end
+
+    context "for a claimed ticket" do
+      let(:ticket) { create(:ticket, :claimed) }
+
+      it "resets it back to being available" do
+        expect{described_class.new.perform(ticket.id)}.to change{ticket.reload.status}.to("available")
+        expect(ticket.name).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
As tickets get claimed but not sold, we need to make them available
again. This PR adds sidekiq and a TicketCleanupWorker that frees up tickets that
have been claimed but not sold, 5 minutes after they are claimed.

I've also updated the Ticket factory.

