### PR TITLE
cycle guid on cleanup

### DIFF
--- a/app/controllers/charge_controller.rb
+++ b/app/controllers/charge_controller.rb
@@ -17,6 +17,11 @@ class ChargeController < ApplicationController
   end
 
   def success
+    if @ticket.nil?
+      flash[:alert] = "It looks like you might be too late for that ticket! Please try again."
+      redirect_to root_path
+    end
+
     @ticket.stripe_checkout_session_id = params[:session_id]
     @ticket.save!
   end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -26,6 +26,8 @@ class Ticket < ApplicationRecord
   def cleanup!
     self.status = "available"
     self.name = nil
+    self.stripe_checkout_session_id = nil
+    set_guid
     save!
   end
 

--- a/spec/workers/ticket_cleanup_worker_spec.rb
+++ b/spec/workers/ticket_cleanup_worker_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe TicketCleanupWorker do
       let(:ticket) { create(:ticket, :claimed) }
 
       it "resets it back to being available" do
+        old_guid = ticket.guid
         expect{described_class.new.perform(ticket.id)}.to change{ticket.reload.status}.to("available")
         expect(ticket.name).to be_nil
+        expect(ticket.stripe_checkout_session_id).to be_nil
+        expect(ticket.guid).to_not eq(old_guid)
       end
     end
   end


### PR DESCRIPTION
This way, a user won't be linked to their old ticket when we run the
cleanup worker.