### PR TITLE
display error for duplicate name

### DIFF
--- a/app/controllers/allocate_controller.rb
+++ b/app/controllers/allocate_controller.rb
@@ -3,11 +3,19 @@ class AllocateController < ApplicationController
     ticket = Ticket.where(event_id: params[:event_id], status: :available).first
 
     if ticket
-      ticket.claim!(params[:name])
-      cookies[:ticket_guid] = ticket.guid
+      begin
+        ticket.claim!(params[:name])
+        cookies[:ticket_guid] = ticket.guid
 
-      respond_to do |format|
-        format.html { redirect_to charge_path }
+        respond_to do |format|
+          format.html { redirect_to charge_path }
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        flash[:alert] = "It looks like you already have a ticket #{params[:name]} and tickets are only 1 per person!"
+
+        respond_to do |format|
+          format.html { redirect_to root_path }
+        end
       end
     end
   end


### PR DESCRIPTION
If a user has previously registered for a ticket, then we want to push
them back to the root path with an error telling them why they can't
proceed.