### PR TITLE
fix turbolinks bug with stripe

### DIFF
--- a/app/views/charge/index.html.erb
+++ b/app/views/charge/index.html.erb
@@ -1,6 +1,4 @@
 <% content_for :head do %>
-  <script src="https://js.stripe.com/v3/"></script>
-
   <script type="text/javascript">
     const setupStripe = () => {
       console.log('setupStripe ran')
@@ -15,7 +13,9 @@
         })
     }
 
-    window.onload = setupStripe;
+    document.addEventListener("turbolinks:load", () => {
+      setupStripe();
+    })
   </script>
 
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://js.stripe.com/v3/"></script>
     <%= yield :head %>
   </head>
 


### PR DESCRIPTION
As Turbolinks is being used to move between pages, the stripe JS needs
loaded first, so this PR moves it to the application layout. It also
runs the setupStripe function on turbolinks:load, to ensure it gets ran
at the right time.