### PR TITLE
update ticket counts on status change

### DIFF
--- a/app/controllers/guests_controller.rb
+++ b/app/controllers/guests_controller.rb
@@ -6,6 +6,11 @@ class GuestsController < ApplicationController
   def reset
     Ticket.destroy_all
     event = Event.first
+    event.update_attributes!({
+      available_tickets_count: 5,
+      claimed_tickets_count: 0,
+      sold_tickets_count: 0,
+    })
 
     5.times do
       Ticket.create!(

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,19 @@
 class Event < ApplicationRecord
+  has_many :tickets
+
+  def update_counts!(ticket)
+    case ticket.status
+    when "claimed" # moving from avilable to claimed
+      self.available_tickets_count -= 1
+      self.claimed_tickets_count += 1
+    when "sold" # moving from claimed to sold
+      self.claimed_tickets_count -= 1
+      self.sold_tickets_count += 1
+    when "available" # moving from claimed to available
+      self.claimed_tickets_count -= 1
+      self.available_tickets_count += 1
+    end
+
+    self.save!
+  end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -16,11 +16,13 @@ class Ticket < ApplicationRecord
     self.status = :claimed
     save!
     TicketCleanupWorker.perform_in(5.minutes, self.id)
+    event.update_counts!(self)
   end
 
   def sell!
     self.status = "sold"
     save!
+    event.update_counts!(self)
   end
 
   def cleanup!
@@ -29,6 +31,7 @@ class Ticket < ApplicationRecord
     self.stripe_checkout_session_id = nil
     set_guid
     save!
+    event.update_counts!(self)
   end
 
   def set_guid

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,4 +5,44 @@ RSpec.describe Event, type: :model do
   it "saves without error" do
     expect {event.save!}.not_to raise_error
   end
+
+  describe "#update_counts!" do
+    context "with a newly claimed ticket" do
+      let(:ticket) { create(:ticket, status: "claimed" )}
+
+      it "updates the claimed and available counts" do
+        event.update_counts!(ticket)
+        expect(event.available_tickets_count).to eq(4)
+        expect(event.claimed_tickets_count).to eq(1)
+      end
+    end
+
+    context "with a newly sold ticket" do
+      let(:event) { create(:event, claimed_tickets_count: 5) }
+      let(:ticket) { create(:ticket, status: "sold" )}
+
+      it "updates the claimed and available counts" do
+        event.update_counts!(ticket)
+        expect(event.claimed_tickets_count).to eq(4)
+        expect(event.sold_tickets_count).to eq(1)
+      end
+    end
+
+    context "with a newly available ticket" do
+      let(:event) {
+        create(:event,
+          available_tickets_count: 0,
+          claimed_tickets_count: 5
+        )
+      }
+
+      let(:ticket) { create(:ticket, status: "available" )}
+
+      it "updates the claimed and available counts" do
+        event.update_counts!(ticket)
+        expect(event.claimed_tickets_count).to eq(4)
+        expect(event.available_tickets_count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Ticket, type: :model do
       expect{ticket.claim!("Tommy")}.to change(TicketCleanupWorker.jobs, :size).by(1)
       expect(ticket.name).to eq("Tommy")
       expect(ticket.claimed?).to eq(true)
+      expect(ticket.event.available_tickets_count).to eq(4)
+      expect(ticket.event.claimed_tickets_count).to eq(1)
     end
   end
 
@@ -20,13 +22,38 @@ RSpec.describe Ticket, type: :model do
     end
   end
 
-  describe "cleanup!" do
-    let(:ticket) { create(:ticket, :claimed) }
+  describe "#cleanup!" do
+    let(:event) {
+      create(:event,
+        available_tickets_count: 0,
+        claimed_tickets_count: 5
+      )
+    }
+    let(:ticket) { create(:ticket, :claimed, event: event) }
 
     it "unclaims the ticket" do
       ticket.cleanup!
       expect(ticket.name).to be_nil
       expect(ticket.status).to eq("available")
+      expect(ticket.event.claimed_tickets_count).to eq(4)
+      expect(ticket.event.available_tickets_count).to eq(1)
+    end
+  end
+
+  describe "#sell!" do
+    let(:event) {
+      create(:event,
+        available_tickets_count: 0,
+        claimed_tickets_count: 5
+      )
+    }
+    let(:ticket) { create(:ticket, :claimed, event: event) }
+
+    it "sells the ticket" do
+      ticket.sell!
+      expect(ticket.status).to eq("sold")
+      expect(ticket.event.claimed_tickets_count).to eq(4)
+      expect(ticket.event.sold_tickets_count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Events hold a count of tickets, so this PR updates the event to have this count changed through the ticket.