### PR TITLE
deal with sold out state

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -42,6 +42,9 @@ input[type="text"] {
   padding: 4px 25px;
   margin-top: 30px;
   text-decoration: none;
+  &:disabled {
+    opacity: 0.5;
+  }
 }
 
 input[type="submit"] {

--- a/app/controllers/allocate_controller.rb
+++ b/app/controllers/allocate_controller.rb
@@ -7,16 +7,16 @@ class AllocateController < ApplicationController
         ticket.claim!(params[:name])
         cookies[:ticket_guid] = ticket.guid
 
-        respond_to do |format|
-          format.html { redirect_to charge_path }
-        end
+        redirect_to charge_path
       rescue ActiveRecord::RecordInvalid => e
         flash[:alert] = "It looks like you already have a ticket #{params[:name]} and tickets are only 1 per person!"
 
-        respond_to do |format|
-          format.html { redirect_to root_path }
-        end
+        redirect_to root_path
       end
+    else
+      flash[:alert] = "It looks like there are no more tickets."
+
+      redirect_to root_path
     end
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,5 +1,6 @@
 class LandingController < ApplicationController
   def index
     @event = Event.first
+    @sold_out = @event.available_tickets_count == 0
   end
 end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -4,17 +4,17 @@
 
 <div class="content">
   <h1>Don't miss your tickets for the best ever show</h1>
-  <% if @event.available_tickets_count > 0 %>
-    <span>only <%= pluralize(@event.available_tickets_count, 'ticket') %> left</span>
-  <% else %>
+  <% if @sold_out %>
     <span>sold out</span>
+  <% else %>
+    <span>only <%= pluralize(@event.available_tickets_count, 'ticket') %> left</span>
   <% end %>
 </div>
 
 <%= form_with(url: allocate_path, method: :post) do %>
   <%= label_tag(:name, "Your name") %>
-  <%= text_field_tag(:name) %>
+  <%= text_field_tag(:name, "", disabled: @sold_out ) %>
   <%= hidden_field_tag(:event_id, @event.id) %>
-  <%= submit_tag("Reserve ticket for 5 minutes") %>
+  <%= submit_tag("Reserve ticket for 5 minutes", disabled: @sold_out) %>
 <% end %>
 

--- a/spec/controllers/allocate_controller_spec.rb
+++ b/spec/controllers/allocate_controller_spec.rb
@@ -3,16 +3,44 @@ require 'rails_helper'
 RSpec.describe AllocateController, type: :controller do
 
   describe "POST /allocate" do
-    let(:ticket) { create(:ticket) }
+    context "when there is a ticket" do
+      let(:ticket) { create(:ticket) }
 
-    it "returns http success" do
-      post :index, params: { name: "John Smith", event_id: ticket.event_id}
+      it "allocates the ticket" do
+        post :index, params: { name: "John Smith", event_id: ticket.event_id}
 
-      ticket.reload
-      expect(ticket.claimed?).to eq(true)
-      expect(ticket.name).to eq("John Smith")
-      expect(response.cookies['ticket_guid']).to eq(ticket.guid)
-      expect(response).to redirect_to(charge_path)
+        ticket.reload
+        expect(ticket.claimed?).to eq(true)
+        expect(ticket.name).to eq("John Smith")
+        expect(response.cookies['ticket_guid']).to eq(ticket.guid)
+        expect(response).to redirect_to(charge_path)
+      end
+    end
+
+    context "when the customer already has a ticket" do
+      let(:ticket) { create(:ticket, :claimed) }
+
+      before do
+        create(:ticket, event: ticket.event)
+      end
+
+      it "redirects to root" do
+        post :index, params: { name: ticket.name, event_id: ticket.event_id}
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("It looks like you already have a ticket John Smith and tickets are only 1 per person!")
+      end
+    end
+
+    context "when there are no more available tickets" do
+      let(:ticket) { create(:ticket, :sold) }
+
+      it "redirects to root" do
+        post :index, params: { name: ticket.name, event_id: ticket.event_id}
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("It looks like there are no more tickets.")
+      end
     end
   end
 


### PR DESCRIPTION
As tickets can become sold out, we want to stop people checking out with them. This PR redirects someone to root if the tickets are sold out and disables the form when there are no tickets available.