### PR TITLE
downgrade sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,4 +61,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'stripe'
 
-gem 'sidekiq'
+gem 'sidekiq', '5.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,11 +196,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (6.0.5)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -261,7 +261,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.beta)
   sass-rails (>= 6)
   selenium-webdriver
-  sidekiq
+  sidekiq (= 5.2.7)
   spring
   spring-watcher-listen (~> 2.0.0)
   stripe


### PR DESCRIPTION
As sidekiq 6 requires redis 4, this is too high for Heroku, which only
provides 3.2.12. This PR installs 5.2.7, which should be low enough to
work.